### PR TITLE
Ticket2976 check for 1 undefined motor macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+.idea/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -15,5 +15,5 @@ if not exist "%gui_dir%" (
     git clone https://github.com/ISISComputingGroup/ibex_gui.git "%gui_dir%"
 )
 
-call c:\Instrument\Apps\Python\genie_python.bat run_tests.py --configs_repo_path "%configs_dir%" --gui_repo_path "%gui_dir%" --reports_path "%reports_dir%" --instruments="DEMO"
+call c:\Instrument\Apps\Python\genie_python.bat run_tests.py --configs_repo_path "%configs_dir%" --gui_repo_path "%gui_dir%" --reports_path "%reports_dir%"
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -15,5 +15,5 @@ if not exist "%gui_dir%" (
     git clone https://github.com/ISISComputingGroup/ibex_gui.git "%gui_dir%"
 )
 
-call c:\Instrument\Apps\Python\genie_python.bat run_tests.py --configs_repo_path "%configs_dir%" --gui_repo_path "%gui_dir%" --reports_path "%reports_dir%"
+call c:\Instrument\Apps\Python\genie_python.bat run_tests.py --configs_repo_path "%configs_dir%" --gui_repo_path "%gui_dir%" --reports_path "%reports_dir%" --instruments="DEMO"
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/tests/configuration_tests.py
+++ b/tests/configuration_tests.py
@@ -84,3 +84,6 @@ class ConfigurationsTests(unittest.TestCase):
             except Exception as e:
                 self.fail("Exception occurred while parsing file {} in configuration {} as XML. Error was: {}"
                           .format(filename, self.config, e))
+
+    def test_GIVEN_a_configuration_WHEN_motors_are_used_THEN_both_or_neither_of_com_setting_and_motor_control_number_are_defined(self):
+        raise NotImplementedError()

--- a/tests/configuration_tests.py
+++ b/tests/configuration_tests.py
@@ -86,4 +86,24 @@ class ConfigurationsTests(unittest.TestCase):
                           .format(filename, self.config, e))
 
     def test_GIVEN_a_configuration_WHEN_motors_are_used_THEN_both_or_neither_of_com_setting_and_motor_control_number_are_defined(self):
-        raise NotImplementedError()
+        iocs_xml = ConfigurationUtils.get_iocs_xml(self.config)
+
+        def get_ioc_prefix(ioc_name):
+            # Extract the IOC prefix from an IOC name (e.g. GALIL_01 -> GALIL)
+            return ioc_name[:-3]
+
+        motor_ioc_prefixes = ["GALIL", "MCLENNAN", "LINMOT", "SM300"]
+        motor_iocs = (ioc for ioc in ConfigurationUtils.get_iocs(iocs_xml) if get_ioc_prefix(ioc) in motor_ioc_prefixes)
+
+        def get_defined_macros_for_ioc(ioc_name):
+            raise NotImplementedError()
+
+        for ioc in motor_iocs:
+            defined_macros = get_defined_macros_for_ioc(ioc)
+
+            controller_number_defined = "MTRCTRL" in defined_macros
+
+            comms_macros = ["COM", "GALILADDR"]
+            comms_macro_defined = len((m for m in comms_macros if m in defined_macros)) > 0
+
+            self.assertTrue(controller_number_defined == comms_macro_defined)  # Both or neither

--- a/tests/configuration_tests.py
+++ b/tests/configuration_tests.py
@@ -3,7 +3,6 @@ import os
 from settings import Settings
 from util.common import CommonUtils
 from util.configurations import ConfigurationUtils
-import itertools
 import xml.etree.ElementTree as ET
 
 

--- a/tests/configuration_tests.py
+++ b/tests/configuration_tests.py
@@ -88,13 +88,7 @@ class ConfigurationsTests(unittest.TestCase):
 
     def test_GIVEN_a_configuration_WHEN_motors_are_used_THEN_both_or_neither_of_com_setting_and_motor_control_number_are_defined(self):
         iocs_xml = self.config_utils.get_iocs_xml(self.config)
-
-        motor_ioc_prefixes = ["GALIL", "MCLENNAN", "LINMOT", "SM300"]
-        max_suffix = 10
-        motor_iocs = ["{}_{:02d}".format(p, i) for p, i in
-                      itertools.product(motor_ioc_prefixes, range(1, max_suffix + 1))]
-
-        for motor_ioc in motor_iocs:
+        for motor_ioc in CommonUtils.MOTOR_IOCS:
             defined_macros = self.config_utils.get_ioc_macros(iocs_xml, motor_ioc, self.config)
 
             controller_number_defined = "MTRCTRL" in defined_macros

--- a/tests/configuration_tests.py
+++ b/tests/configuration_tests.py
@@ -98,6 +98,6 @@ class ConfigurationsTests(unittest.TestCase):
             defined_macros = self.config_utils.get_ioc_macros(iocs_xml, motor_ioc, self.config)
 
             controller_number_defined = "MTRCTRL" in defined_macros
-            comms_macro_defined = any(m in defined_macros for m in ["COM", "GALILADDR"])
+            comms_macro_defined = any(m in defined_macros for m in ["PORT", "GALILADDR"])
 
             self.assertTrue(controller_number_defined == comms_macro_defined)  # Both or neither

--- a/tests/globals_tests.py
+++ b/tests/globals_tests.py
@@ -2,6 +2,7 @@ import unittest
 from settings import Settings
 from util.globals import GlobalsUtils
 from six import string_types
+import itertools
 
 
 class GlobalsTests(unittest.TestCase):
@@ -26,3 +27,18 @@ class GlobalsTests(unittest.TestCase):
     def test_WHEN_checking_the_configs_directory_THEN_there_are_no_extra_files_called_globals(self):
         self.assertEqual(self.globals_utils.get_number_of_globals_files(), 1 if self.globals_utils.file_exists() else 0,
                          "Extra globals files ({}) files in repository.".format(self.globals_utils.GLOBALS_FILE))
+
+    def test_WHEN_macros_are_defined_in_globals_for_a_motor_ioc_THEN_both_or_neither_of_com_setting_and_motor_control_number_are_defined(self):
+
+        motor_ioc_prefixes = ["GALIL", "MCLENNAN", "LINMOT", "SM300"]
+        max_suffix = 10
+        motor_iocs = ["{}_{:02d}".format(p, i) for p, i in
+                      itertools.product(motor_ioc_prefixes, range(1, max_suffix + 1))]
+
+        for motor_ioc in motor_iocs:
+            defined_macros = self.globals_utils.get_macros(motor_ioc)
+
+            controller_number_defined = "MTRCTRL" in defined_macros
+            comms_macro_defined = any(m in defined_macros for m in ["PORT", "GALILADDR"])
+
+            self.assertTrue(controller_number_defined == comms_macro_defined)  # Both or neither

--- a/tests/globals_tests.py
+++ b/tests/globals_tests.py
@@ -3,7 +3,6 @@ from settings import Settings
 from util.globals import GlobalsUtils
 from util.common import CommonUtils
 from six import string_types
-import itertools
 
 
 class GlobalsTests(unittest.TestCase):

--- a/tests/globals_tests.py
+++ b/tests/globals_tests.py
@@ -1,6 +1,7 @@
 import unittest
 from settings import Settings
 from util.globals import GlobalsUtils
+from util.common import CommonUtils
 from six import string_types
 import itertools
 
@@ -29,13 +30,7 @@ class GlobalsTests(unittest.TestCase):
                          "Extra globals files ({}) files in repository.".format(self.globals_utils.GLOBALS_FILE))
 
     def test_WHEN_macros_are_defined_in_globals_for_a_motor_ioc_THEN_both_or_neither_of_com_setting_and_motor_control_number_are_defined(self):
-
-        motor_ioc_prefixes = ["GALIL", "MCLENNAN", "LINMOT", "SM300"]
-        max_suffix = 10
-        motor_iocs = ["{}_{:02d}".format(p, i) for p, i in
-                      itertools.product(motor_ioc_prefixes, range(1, max_suffix + 1))]
-
-        for motor_ioc in motor_iocs:
+        for motor_ioc in CommonUtils.MOTOR_IOCS:
             defined_macros = self.globals_utils.get_macros(motor_ioc)
 
             controller_number_defined = "MTRCTRL" in defined_macros

--- a/util/common.py
+++ b/util/common.py
@@ -1,4 +1,4 @@
-import json
+import itertools
 import os
 
 
@@ -6,6 +6,8 @@ class CommonUtils(object):
     """
     Class containing utility methods common to several other utilities
     """
+    MOTOR_IOCS = ["{}_{:02d}".format(p, i) for p, i in
+                  itertools.product(["GALIL", "MCLENNAN", "LINMOT", "SM300"], range(1, 11))]
 
     @staticmethod
     def get_directory_contents_as_list(path):

--- a/util/configurations.py
+++ b/util/configurations.py
@@ -57,15 +57,11 @@ class AbstractConfigurationUtils(object):
         root = ET.fromstring(xml)
         ioc_xml = tuple(ioc for ioc in root.iter("{}ioc".format(self.XML_SCHEMA)) if ioc.attrib["name"] == ioc_name)
 
-        # Assert that we found exactly 1 IOC with the right name
-        if len(ioc_xml) == 0:
-            raise ValueError("Unable to find IOC {} in IOC XML for config {}".format(ioc_name, config_name))
-        elif len(ioc_xml) > 1:
-            raise ValueError("Unable to identify unique IOC {} in IOC XML for config {}".format(
-                len(ioc_xml), config_name))
-
         # Extract the macros
-        return {m.attrib["name"]: m.attrib["value"] for m in ioc_xml[0].iter("{}macro".format(self.XML_SCHEMA))}
+        if len(ioc_xml) == 0:
+            return dict()
+        else:
+            return {m.attrib["name"]: m.attrib["value"] for m in ioc_xml[0].iter("{}macro".format(self.XML_SCHEMA))}
 
 
 class ConfigurationUtils(AbstractConfigurationUtils):

--- a/util/configurations.py
+++ b/util/configurations.py
@@ -44,6 +44,29 @@ class AbstractConfigurationUtils(object):
 
         return iocs
 
+    def get_ioc_macros(self, xml, ioc_name, config_name):
+        """
+        Returns a dictionary of macro information for a given ioc_name in the given xml.
+
+        :param xml: The IOC xml.
+        :param ioc_name: The name of the ioc.
+        :param config_name: The name of the configuration we're looking in.
+        :return: A dictionary of macro information. Keys are the macro name, values are the macro value
+        """
+        # Parse the XML
+        root = ET.fromstring(xml)
+        ioc_xml = tuple(ioc for ioc in root.iter("{}ioc".format(self.XML_SCHEMA)) if ioc.attrib["name"] == ioc_name)
+
+        # Assert that we found exactly 1 IOC with the right name
+        if len(ioc_xml) == 0:
+            raise ValueError("Unable to find IOC {} in IOC XML for config {}".format(ioc_name, config_name))
+        elif len(ioc_xml) > 1:
+            raise ValueError("Unable to identify unique IOC {} in IOC XML for config {}".format(
+                len(ioc_xml), config_name))
+
+        # Extract the macros
+        return {m.attrib["name"]: m.attrib["value"] for m in ioc_xml[0].iter("{}macro".format(self.XML_SCHEMA))}
+
 
 class ConfigurationUtils(AbstractConfigurationUtils):
     """

--- a/util/globals.py
+++ b/util/globals.py
@@ -34,6 +34,20 @@ class GlobalsUtils(object):
         except IOError:
             return []
 
+    def get_macros(self, ioc_name):
+        """
+        Get the macros associated with an ioc of the given name
+        :param ioc_name: Name of the IOC to search for
+        :return: A dictionary of macros (keys) and values
+        """
+        lines = self.get_lines()
+        macros = dict()
+        for line in lines:
+            if line.startswith(ioc_name):
+                key, value = line.replace("{}__".format(ioc_name), "").split("=")
+                macros[key] = value
+        return macros
+
     @staticmethod
     def check_syntax(line):
         # Remove comments, discard anything after a "#" sign

--- a/util/test_utils/test_configurations.py
+++ b/util/test_utils/test_configurations.py
@@ -80,7 +80,7 @@ class ConfigurationTests(unittest.TestCase):
         self.assertEqual(macros_2[name_1], value_1_02)
         self.assertEqual(macros_2[name_2], value_2_02)
 
-    def test_GIVEN_ioc_xml_WHEN_macros_requested_for_ioc_that_does_not_exist_THEN_causes_exception(self):
+    def test_GIVEN_ioc_xml_WHEN_macros_requested_for_ioc_that_does_not_exist_THEN_returns_no_data(self):
 
         xml = """<?xml version="1.0" ?>
                     <iocs xmlns="http://epics.isis.rl.ac.uk/schema/iocs/1.0" 
@@ -89,5 +89,5 @@ class ConfigurationTests(unittest.TestCase):
                     </iocs>
                     """
 
-        with self.assertRaises(ValueError):
-            self.config_utils.get_ioc_macros(xml, "SIMPL", "test_config")
+        self.assertEqual(len(self.config_utils.get_ioc_macros(xml, "SIMPL", "test_config").values()), 0)
+

--- a/util/test_utils/test_configurations.py
+++ b/util/test_utils/test_configurations.py
@@ -3,7 +3,6 @@ import unittest
 
 
 class ConfigurationTests(unittest.TestCase):
-
     def setUp(self):
         self.config_utils = ConfigurationUtils("")
 
@@ -39,3 +38,56 @@ class ConfigurationTests(unittest.TestCase):
                     """
 
         self.assertListEqual(self.config_utils.get_iocs(xml), ["SIMPLE_01", "SIMPLE_02"])
+
+    def test_GIVEN_ioc_xml_WHEN_macros_requested_for_ioc_that_exists_THEN_macro_information_matches_xml(self):
+        name_1 = "macro1"
+        value_1_01 = "1"
+        value_1_02 = "Hello, world!"
+
+        name_2 = "macro2"
+        value_2_01 = "3.45"
+        value_2_02 = "0x2a"
+
+        xml = """<?xml version="1.0" ?>
+                    <iocs xmlns="http://epics.isis.rl.ac.uk/schema/iocs/1.0" 
+                    xmlns:ioc="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+                        <ioc autostart="true" name="SIMPLE_01" restart="false" simlevel="none">
+                            <macros>
+                                <macro name="{name_1}" value="{value_1_01}"/>
+                                <macro name="{name_2}" value="{value_2_01}"/>
+                            </macros>
+                            <pvs/>
+                            <pvsets/>
+                        </ioc>
+                        <ioc autostart="true" name="SIMPLE_02" restart="false" simlevel="none">
+                            <macros>
+                                <macro name="{name_1}" value="{value_1_02}"/>
+                                <macro name="{name_2}" value="{value_2_02}"/>
+                            </macros>
+                            <pvs/>
+                            <pvsets/>
+                        </ioc>
+                    </iocs>
+                    """.format(name_1=name_1, name_2=name_2,
+                               value_1_01=value_1_01, value_1_02=value_1_02,
+                               value_2_01=value_2_01, value_2_02=value_2_02)
+
+        macros_1 = self.config_utils.get_ioc_macros(xml, "SIMPLE_01", "test_config")
+        self.assertEqual(macros_1[name_1], value_1_01)
+        self.assertEqual(macros_1[name_2], value_2_01)
+
+        macros_2 = self.config_utils.get_ioc_macros(xml, "SIMPLE_02", "test_config")
+        self.assertEqual(macros_2[name_1], value_1_02)
+        self.assertEqual(macros_2[name_2], value_2_02)
+
+    def test_GIVEN_ioc_xml_WHEN_macros_requested_for_ioc_that_does_not_exist_THEN_causes_exception(self):
+
+        xml = """<?xml version="1.0" ?>
+                    <iocs xmlns="http://epics.isis.rl.ac.uk/schema/iocs/1.0" 
+                    xmlns:ioc="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+                        <ioc autostart="true" name="SIMPLE_01" restart="false" simlevel="none" />
+                    </iocs>
+                    """
+
+        with self.assertRaises(ValueError):
+            self.config_utils.get_ioc_macros(xml, "SIMPL", "test_config")

--- a/util/test_utils/test_globals.py
+++ b/util/test_utils/test_globals.py
@@ -1,5 +1,6 @@
 import unittest
 from util.globals import GlobalsUtils
+from mock import Mock
 
 
 class GlobalsTests(unittest.TestCase):
@@ -146,3 +147,35 @@ class GlobalsTests(unittest.TestCase):
 
         # Assert
         self.assertFalse(result)
+
+    def test_GIVEN_a_line_WHEN_macro_requested_for_correct_ioc_name_THEN_key_and_value_matches_input(self):
+        # Arrange
+        ioc_name = "MYIOC_01"
+        macro = "macro"
+        value = "01"
+        line = "{}__{}={}".format(ioc_name, macro, value)
+
+        self.utils.get_lines = Mock(return_value=[line])
+
+        # Act
+        result = self.utils.get_macros(ioc_name)
+
+        # Assert
+        self.assertEqual(len(result.keys()), 1)
+        self.assertTrue(result.has_key(macro))
+        self.assertEqual(result[macro], value)
+
+    def test_GIVEN_a_line_WHEN_macro_requested_for_non_existant_ioc_THEN_no_macros_returned(self):
+        # Arrange
+        ioc_name = "MYIOC_01"
+        macro = "macro"
+        value = "01"
+        line = "{}__{}={}".format(ioc_name, macro, value)
+
+        self.utils.get_lines = Mock(return_value=[line])
+
+        # Act
+        result = self.utils.get_macros("not_" + ioc_name)
+
+        # Assert
+        self.assertEqual(len(result.keys()), 0)


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/2976

Add a test in the config checker which verifies whether both or neither macros in motor IOCs has been set. This should help identify possible auto save errors.

Test should currently fail on DEMO. I'll remove the error once the PR is merged