### PR TITLE
Make get_ioc_usage case insensitive

### DIFF
--- a/get_ioc_usage.py
+++ b/get_ioc_usage.py
@@ -54,7 +54,7 @@ def print_instruments_with_ioc(instrument_configs, ioc_name):
     for instrument, iocs in instrument_configs.items():
 
         for ioc in iocs:
-            if ioc.startswith(ioc_name):
+            if ioc.lower().startswith(ioc_name.lower()):
                 print(instrument)
                 break
 


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/3467

Acceptance criteria:
- The script is not case sensitive with respect to IOC name

Run using `get_ioc_usage.bat --ioc tpg26x` to test