### PR TITLE
Ticket4374 configchecker test for duplicate ioc

### DIFF
--- a/util/configurations.py
+++ b/util/configurations.py
@@ -21,6 +21,39 @@ class AbstractConfigurationUtils(object):
     def get_configurations_as_list(self):
         return CommonUtils.get_folders_in_directory_as_list(self.get_configurations_directory())
 
+    def get_active_components_as_list(self, config_name):
+        """
+        Gets a list of active components for a particular configuration.
+        :param config_name: the configuration name
+        :return: a list of components
+        """
+        return self.get_active_components_from_xml(self.get_components_xml(config_name))
+
+    def get_components_xml(self, config_name):
+        """
+        Gets the XML corresponding to the components file for a particular configuration.
+        :param config_name: the configuration name
+        :return: the XML as a string
+        """
+        path = os.path.join(self.get_configurations_directory(), config_name, "components.xml")
+
+        with open(path) as f:
+            return f.read()
+
+    def get_active_components_from_xml(self, xml):
+        """
+        Gets a list of active components from a component XML.
+        :param xml: a components XML as a string
+        :return: a list of components
+        """
+        root = ET.fromstring(xml)
+
+        components = []
+        for component in root.iter("{http://epics.isis.rl.ac.uk/schema/components/1.0}component"):
+            components.append(component.attrib["name"])
+
+        return components
+
     def get_iocs_xml(self, config_name):
         """
         Gets the XML corresponding to the IOCs file for a particular configuration.

--- a/util/test_utils/test_configurations.py
+++ b/util/test_utils/test_configurations.py
@@ -39,6 +39,29 @@ class ConfigurationTests(unittest.TestCase):
 
         self.assertListEqual(self.config_utils.get_iocs(xml), ["SIMPLE_01", "SIMPLE_02"])
 
+    def test_GIVEN_component_xml_WHEN_parsed_THEN_can_extract_a_single_component(self):
+        xml = """<?xml version="1.0" ?>
+                     <components xmlns="http://epics.isis.rl.ac.uk/schema/components/1.0"
+                     xmlns:comp="http://epics.isis.rl.ac.uk/schema/components/1.0"
+                     xmlns:xi="http://www.w3.org/2001/XInclude">
+                         <component name="COMPONENT_1"/>
+                     </components>
+              """
+
+        self.assertListEqual(self.config_utils.get_active_components_from_xml(xml), ["COMPONENT_1"])
+
+    def test_GIVEN_component_xml_WHEN_parsed_THEN_can_extract_multiple_components(self):
+        xml = """<?xml version="1.0" ?>
+                     <components xmlns="http://epics.isis.rl.ac.uk/schema/components/1.0"
+                     xmlns:comp="http://epics.isis.rl.ac.uk/schema/components/1.0"
+                     xmlns:xi="http://www.w3.org/2001/XInclude">
+                         <component name="COMPONENT_1"/>
+                         <component name="COMPONENT_2"/>
+                     </components>
+              """
+
+        self.assertListEqual(self.config_utils.get_active_components_from_xml(xml), ["COMPONENT_1", "COMPONENT_2"])
+
     def test_GIVEN_ioc_xml_WHEN_macros_requested_for_ioc_that_exists_THEN_macro_information_matches_xml(self):
         name_1 = "macro1"
         value_1_01 = "1"


### PR DESCRIPTION
### Description of work

Added a test for having multiple instances of the same ioc in a configuration.
The config checker now fails several times on this test (as expected).

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4374

### Acceptance criteria

- [ ] Configchecker fails when a configuration contains multiple instances of the same IOC (including component IOCs).

### Unit tests

Wrote a couple of unit tests for the component xml parsing which was added.

### Documentation
Updated [this](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Config-Checker).

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

