### PR TITLE
Convert ConfigChecker to Python 3

### DIFF
--- a/build/update_genie_python.bat
+++ b/build/update_genie_python.bat
@@ -3,8 +3,8 @@ setlocal
 REM It only takes two or three minutes to do a full install, so for simplicity we do that.
 REM it is installed using xcopy /d, so if it hasn't changed then it doesn't do anything.
 
-set PYTHON_KITS_PATH=p:\Kits$\CompGroup\ICP\genie_python\
-set PYTHON_INSTALL_DIR=C:\Instrument\Apps\Python
+set PYTHON_KITS_PATH=p:\Kits$\CompGroup\ICP\genie_python_3\
+set PYTHON_INSTALL_DIR=C:\Instrument\Apps\Python3
 
 @echo Updating genie_python
 

--- a/get_ioc_usage.bat
+++ b/get_ioc_usage.bat
@@ -15,5 +15,5 @@ if not exist "%gui_dir%" (
     git clone https://github.com/ISISComputingGroup/ibex_gui.git "%gui_dir%"
 )
 
-call c:\Instrument\Apps\Python\genie_python.bat get_ioc_usage.py --configs_repo_path "%configs_dir%" --gui_repo_path "%gui_dir%" %*
+call c:\Instrument\Apps\Python3\genie_python.bat get_ioc_usage.py --configs_repo_path "%configs_dir%" --gui_repo_path "%gui_dir%" %*
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/get_ioc_usage.py
+++ b/get_ioc_usage.py
@@ -3,11 +3,11 @@ from __future__ import absolute_import
 import os
 import argparse
 
-from .run_tests import setup_instrument_tests
-from .tests.settings import Settings
+from run_tests import setup_instrument_tests
+from tests.settings import Settings
 
-from .util.channel_access import ChannelAccessUtils
-from .util.configurations import ConfigurationUtils, ComponentUtils
+from util.channel_access import ChannelAccessUtils
+from util.configurations import ConfigurationUtils, ComponentUtils
 
 
 def calc_iocs_on_intruments(instruments):

--- a/get_ioc_usage.py
+++ b/get_ioc_usage.py
@@ -41,7 +41,7 @@ def print_iocs_on_instruments(instrument_configs):
     :param instrument_configs: instrument ioc config dictionary
     """
 
-    for instrument, iocs in list(instrument_configs.items()):
+    for instrument, iocs in instrument_configs.items():
         print(instrument)
         print("    - {}\n".format("\n    - ".join(sorted(iocs))))
 
@@ -53,7 +53,7 @@ def print_instruments_with_ioc(instrument_configs, ioc_name):
     :param ioc_name: name of the ioc
     """
     print("All those having the {}".format(ioc_name))
-    for instrument, iocs in list(instrument_configs.items()):
+    for instrument, iocs in instrument_configs.items():
 
         for ioc in iocs:
             if ioc.lower().startswith(ioc_name.lower()):
@@ -87,7 +87,7 @@ def main():
         raise IOError("No instruments found. This is probably because the instrument list PV is unavailable.")
 
     if args.instruments is not None:
-        instruments = list([x for x in instruments if x["name"] in args.instruments])
+        instruments = [x for x in instruments if x["name"] in args.instruments]
         if len(instruments) < len(args.instruments):
             raise ValueError("Some instruments specified could not be found in the instrument list.")
 

--- a/get_ioc_usage.py
+++ b/get_ioc_usage.py
@@ -1,11 +1,13 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 import argparse
 
-from run_tests import setup_instrument_tests
-from tests.settings import Settings
+from .run_tests import setup_instrument_tests
+from .tests.settings import Settings
 
-from util.channel_access import ChannelAccessUtils
-from util.configurations import ConfigurationUtils, ComponentUtils
+from .util.channel_access import ChannelAccessUtils
+from .util.configurations import ConfigurationUtils, ComponentUtils
 
 
 def calc_iocs_on_intruments(instruments):
@@ -39,7 +41,7 @@ def print_iocs_on_instruments(instrument_configs):
     :param instrument_configs: instrument ioc config dictionary
     """
 
-    for instrument, iocs in instrument_configs.items():
+    for instrument, iocs in list(instrument_configs.items()):
         print(instrument)
         print("    - {}\n".format("\n    - ".join(sorted(iocs))))
 
@@ -51,7 +53,7 @@ def print_instruments_with_ioc(instrument_configs, ioc_name):
     :param ioc_name: name of the ioc
     """
     print("All those having the {}".format(ioc_name))
-    for instrument, iocs in instrument_configs.items():
+    for instrument, iocs in list(instrument_configs.items()):
 
         for ioc in iocs:
             if ioc.lower().startswith(ioc_name.lower()):
@@ -85,7 +87,7 @@ def main():
         raise IOError("No instruments found. This is probably because the instrument list PV is unavailable.")
 
     if args.instruments is not None:
-        instruments = list(filter(lambda x: x["name"] in args.instruments, instruments))
+        instruments = list([x for x in instruments if x["name"] in args.instruments])
         if len(instruments) < len(args.instruments):
             raise ValueError("Some instruments specified could not be found in the instrument list.")
 

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -15,5 +15,5 @@ if not exist "%gui_dir%" (
     git clone https://github.com/ISISComputingGroup/ibex_gui.git "%gui_dir%"
 )
 
-call c:\Instrument\Apps\Python\genie_python.bat run_tests.py --configs_repo_path "%configs_dir%" --gui_repo_path "%gui_dir%" --reports_path "%reports_dir%"
+call c:\Instrument\Apps\Python3\genie_python.bat run_tests.py --configs_repo_path "%configs_dir%" --gui_repo_path "%gui_dir%" --reports_path "%reports_dir%"
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import str
 import os
 import sys
 import unittest
@@ -5,18 +8,18 @@ from xmlrunner import XMLTestRunner
 import argparse
 import traceback
 
-from tests.configuration_tests import ConfigurationsTests, ConfigurationsSingleTests
-from tests.component_tests import ComponentsTests, ComponentsSingleTests
-from tests.globals_tests import GlobalsTests
-from tests.scripting_directory_tests import ScriptingDirectoryTests
-from tests.synoptic_tests import SynopticTests
-from tests.version_tests import VersionTests
-from tests.settings import Settings
+from .tests.configuration_tests import ConfigurationsTests, ConfigurationsSingleTests
+from .tests.component_tests import ComponentsTests, ComponentsSingleTests
+from .tests.globals_tests import GlobalsTests
+from .tests.scripting_directory_tests import ScriptingDirectoryTests
+from .tests.synoptic_tests import SynopticTests
+from .tests.version_tests import VersionTests
+from .tests.settings import Settings
 
-from util.channel_access import ChannelAccessUtils
-from util.configurations import ConfigurationUtils, ComponentUtils
-from util.git_wrapper import GitUtils
-from util.synoptic import SynopticUtils
+from .util.channel_access import ChannelAccessUtils
+from .util.configurations import ConfigurationUtils, ComponentUtils
+from .util.git_wrapper import GitUtils
+from .util.synoptic import SynopticUtils
 
 
 def run_instrument_tests(inst_name, reports_path):
@@ -153,7 +156,7 @@ def main():
         raise IOError("No instruments found. This is probably because the instrument list PV is unavailable.")
 
     if args.instruments is not None:
-        instruments = list(filter(lambda x: x["name"] in args.instruments, instruments))
+        instruments = list([x for x in instruments if x["name"] in args.instruments])
         if len(instruments) < len(args.instruments):
             raise ValueError("Some instruments specified could not be found in the instrument list.")
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -8,18 +8,18 @@ from xmlrunner import XMLTestRunner
 import argparse
 import traceback
 
-from .tests.configuration_tests import ConfigurationsTests, ConfigurationsSingleTests
-from .tests.component_tests import ComponentsTests, ComponentsSingleTests
-from .tests.globals_tests import GlobalsTests
-from .tests.scripting_directory_tests import ScriptingDirectoryTests
-from .tests.synoptic_tests import SynopticTests
-from .tests.version_tests import VersionTests
-from .tests.settings import Settings
+from tests.configuration_tests import ConfigurationsTests, ConfigurationsSingleTests
+from tests.component_tests import ComponentsTests, ComponentsSingleTests
+from tests.globals_tests import GlobalsTests
+from tests.scripting_directory_tests import ScriptingDirectoryTests
+from tests.synoptic_tests import SynopticTests
+from tests.version_tests import VersionTests
+from tests.settings import Settings
 
-from .util.channel_access import ChannelAccessUtils
-from .util.configurations import ConfigurationUtils, ComponentUtils
-from .util.git_wrapper import GitUtils
-from .util.synoptic import SynopticUtils
+from util.channel_access import ChannelAccessUtils
+from util.configurations import ConfigurationUtils, ComponentUtils
+from util.git_wrapper import GitUtils
+from util.synoptic import SynopticUtils
 
 
 def run_instrument_tests(inst_name, reports_path):

--- a/run_tests.py
+++ b/run_tests.py
@@ -156,7 +156,7 @@ def main():
         raise IOError("No instruments found. This is probably because the instrument list PV is unavailable.")
 
     if args.instruments is not None:
-        instruments = list([x for x in instruments if x["name"] in args.instruments])
+        instruments = [x for x in instruments if x["name"] in args.instruments]
         if len(instruments) < len(args.instruments):
             raise ValueError("Some instruments specified could not be found in the instrument list.")
 

--- a/tests/abstract_test_utils.py
+++ b/tests/abstract_test_utils.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import unittest
 import six
 
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod
 from .settings import Settings
 from util.channel_access import ChannelAccessUtils
 
@@ -15,7 +15,8 @@ class AbstractSingleTests(unittest.TestCase):
     to be extended by classes for configurations and for components.
     """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def utils(self):
         """
         Create an abstract property (utils) that must be implemented by the implementing class, and should be implemented
@@ -25,7 +26,8 @@ class AbstractSingleTests(unittest.TestCase):
         """
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def type(self):
         """
         Create an abstract property (type) that must be implemented by the implementing class, and should be implemented

--- a/tests/abstract_test_utils.py
+++ b/tests/abstract_test_utils.py
@@ -1,8 +1,10 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import unittest
 import six
 
 from abc import ABCMeta, abstractmethod, abstractproperty
-from settings import Settings
+from .settings import Settings
 from util.channel_access import ChannelAccessUtils
 
 

--- a/tests/component_tests.py
+++ b/tests/component_tests.py
@@ -1,11 +1,12 @@
+from __future__ import absolute_import
 import unittest
 import os
 import xml.etree.ElementTree as ET
 
-from settings import Settings
+from .settings import Settings
 from util.common import CommonUtils, skip_on_instruments
 from util.configurations import ComponentUtils
-from abstract_test_utils import AbstractSingleTests
+from .abstract_test_utils import AbstractSingleTests
 
 
 class ComponentsSingleTests(AbstractSingleTests):

--- a/tests/configuration_tests.py
+++ b/tests/configuration_tests.py
@@ -1,11 +1,12 @@
+from __future__ import absolute_import
 import unittest
 import os
 import xml.etree.ElementTree as ET
 
-from settings import Settings
+from .settings import Settings
 from util.common import CommonUtils, skip_on_instruments
 from util.configurations import ConfigurationUtils, ComponentUtils
-from abstract_test_utils import AbstractSingleTests
+from .abstract_test_utils import AbstractSingleTests
 
 
 class ConfigurationsSingleTests(AbstractSingleTests):

--- a/tests/globals_tests.py
+++ b/tests/globals_tests.py
@@ -1,5 +1,6 @@
+from __future__ import absolute_import
 import unittest
-from settings import Settings
+from .settings import Settings
 from util.globals import GlobalsUtils
 from util.common import CommonUtils, skip_on_instruments
 from six import string_types

--- a/tests/scripting_directory_tests.py
+++ b/tests/scripting_directory_tests.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import unittest
 import os
 from unittest import skip
 
-from settings import Settings
+from .settings import Settings
 from util.scripting import ScriptingUtils
 
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,3 +1,4 @@
+from builtins import object
 from util.channel_access import ChannelAccessUtils
 
 

--- a/tests/synoptic_tests.py
+++ b/tests/synoptic_tests.py
@@ -87,7 +87,7 @@ class SynopticTests(unittest.TestCase):
         except Exception as e:
             self.fail("In synoptic {}, XML failed to parse properly. Error text was: {}".format(self.synoptic, e))
         else:
-            invalid_names = [name for name in pvs.keys() if pvs[name] is None]
+            invalid_names = [name for name in list(pvs.keys()) if pvs[name] is None]
             error_msg = "Synoptic {} contains the following PV names with no associated address:\n    {}".format(
                 self.synoptic, "\n    ".join(invalid_names))
             self.assertEqual(len(invalid_names), 0, error_msg)

--- a/tests/synoptic_tests.py
+++ b/tests/synoptic_tests.py
@@ -87,7 +87,7 @@ class SynopticTests(unittest.TestCase):
         except Exception as e:
             self.fail("In synoptic {}, XML failed to parse properly. Error text was: {}".format(self.synoptic, e))
         else:
-            invalid_names = [name for name in list(pvs.keys()) if pvs[name] is None]
+            invalid_names = [name for name in pvs.keys() if pvs[name] is None]
             error_msg = "Synoptic {} contains the following PV names with no associated address:\n    {}".format(
                 self.synoptic, "\n    ".join(invalid_names))
             self.assertEqual(len(invalid_names), 0, error_msg)

--- a/util/channel_access.py
+++ b/util/channel_access.py
@@ -83,7 +83,7 @@ class ChannelAccessUtils(object):
         :return: a list of strings representing IOC names.
         """
         pv_value = self.get_value("CS:BLOCKSERVER:IOCS")
-        return None if pv_value is None else list(json.loads(self._dehex_and_decompress(pv_value)).keys())
+        return None if pv_value is None else json.loads(self._dehex_and_decompress(pv_value)).keys()
 
     def get_protected_iocs(self):
         """

--- a/util/channel_access.py
+++ b/util/channel_access.py
@@ -1,3 +1,4 @@
+from builtins import object
 import json
 import zlib
 
@@ -81,7 +82,7 @@ class ChannelAccessUtils(object):
         :return: a list of strings representing IOC names.
         """
         pv_value = self.get_value("CS:BLOCKSERVER:IOCS")
-        return None if pv_value is None else json.loads(self._dehex_and_decompress(pv_value)).keys()
+        return None if pv_value is None else list(json.loads(self._dehex_and_decompress(pv_value)).keys())
 
     def get_protected_iocs(self):
         """

--- a/util/channel_access.py
+++ b/util/channel_access.py
@@ -1,6 +1,7 @@
 from builtins import object
 import json
 import zlib
+import binascii
 
 from enum import Enum
 from genie_python.genie_cachannel_wrapper import CaChannelWrapper
@@ -33,7 +34,7 @@ class ChannelAccessUtils(object):
         PV.
         :return: The data of the PV in the form of a decompressed and decoded string.
         """
-        return zlib.decompress(data.decode('hex'))
+        return zlib.decompress(binascii.unhexlify(data))
 
     def get_inst_list(self):
         """

--- a/util/common.py
+++ b/util/common.py
@@ -1,3 +1,5 @@
+from builtins import range
+from builtins import object
 import itertools
 import os
 import unittest
@@ -12,7 +14,7 @@ class CommonUtils(object):
     Class containing utility methods common to several other utilities
     """
     MOTOR_IOCS = ["{}_{:02d}".format(p, i) for p, i in
-                  itertools.product(["GALIL", "MCLENNAN", "LINMOT", "SM300"], range(1, 11))]
+                  itertools.product(["GALIL", "MCLENNAN", "LINMOT", "SM300"], list(range(1, 11)))]
 
     @staticmethod
     def get_directory_contents_as_list(path):

--- a/util/common.py
+++ b/util/common.py
@@ -14,7 +14,7 @@ class CommonUtils(object):
     Class containing utility methods common to several other utilities
     """
     MOTOR_IOCS = ["{}_{:02d}".format(p, i) for p, i in
-                  itertools.product(["GALIL", "MCLENNAN", "LINMOT", "SM300"], list(range(1, 11)))]
+                  itertools.product(["GALIL", "MCLENNAN", "LINMOT", "SM300"], range(1, 11))]
 
     @staticmethod
     def get_directory_contents_as_list(path):

--- a/util/configurations.py
+++ b/util/configurations.py
@@ -1,7 +1,9 @@
+from __future__ import absolute_import
+from builtins import object
 import os
 import xml.etree.ElementTree as ET
 
-from common import CommonUtils
+from .common import CommonUtils
 from tests.settings import Settings
 
 

--- a/util/git_wrapper.py
+++ b/util/git_wrapper.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from builtins import object
 import git
 
 

--- a/util/globals.py
+++ b/util/globals.py
@@ -76,9 +76,9 @@ class GlobalsUtils(object):
         """
         :return: TRUE if any simulation flags are set
         """
-        has_recsim = "1" in list(self.get_values_of_macro("RECSIM").values())
-        has_devsim = "1" in list(self.get_values_of_macro("DEVSIM").values())
-        has_simulate = "1" in list(self.get_values_of_macro("SIMULATE").values())
+        has_recsim = "1" in self.get_values_of_macro("RECSIM").values()
+        has_devsim = "1" in self.get_values_of_macro("DEVSIM").values()
+        has_simulate = "1" in self.get_values_of_macro("SIMULATE").values()
         return has_recsim or has_devsim or has_simulate
 
     @staticmethod

--- a/util/globals.py
+++ b/util/globals.py
@@ -1,3 +1,4 @@
+from builtins import object
 import os
 import re
 
@@ -75,9 +76,9 @@ class GlobalsUtils(object):
         """
         :return: TRUE if any simulation flags are set
         """
-        has_recsim = "1" in self.get_values_of_macro("RECSIM").values()
-        has_devsim = "1" in self.get_values_of_macro("DEVSIM").values()
-        has_simulate = "1" in self.get_values_of_macro("SIMULATE").values()
+        has_recsim = "1" in list(self.get_values_of_macro("RECSIM").values())
+        has_devsim = "1" in list(self.get_values_of_macro("DEVSIM").values())
+        has_simulate = "1" in list(self.get_values_of_macro("SIMULATE").values())
         return has_recsim or has_devsim or has_simulate
 
     @staticmethod

--- a/util/gui.py
+++ b/util/gui.py
@@ -1,3 +1,4 @@
+from builtins import object
 from util.git_wrapper import GitUtils
 import xml.etree.ElementTree as ET
 import os

--- a/util/scripting.py
+++ b/util/scripting.py
@@ -1,3 +1,4 @@
+from builtins import object
 import os
 import git
 

--- a/util/synoptic.py
+++ b/util/synoptic.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
+from builtins import object
 import xml.etree.ElementTree as ET
 import os
-from common import CommonUtils
+from .common import CommonUtils
 
 
 class SynopticUtils(object):

--- a/util/test_utils/test_configurations.py
+++ b/util/test_utils/test_configurations.py
@@ -221,7 +221,7 @@ class ConfigurationTests(unittest.TestCase):
                     </iocs>
                     """
 
-        self.assertEqual(len(list(self.config_utils.get_ioc_macros(xml, "SIMPL").values())), 0)
+        self.assertEqual(len(self.config_utils.get_ioc_macros(xml, "SIMPL").values()), 0)
 
     def test_GIVEN_ioc_xml_WHEN_simlevel_is_not_none_THEN_returns_false(self):
         xml = """<?xml version="1.0" ?>

--- a/util/test_utils/test_configurations.py
+++ b/util/test_utils/test_configurations.py
@@ -221,7 +221,7 @@ class ConfigurationTests(unittest.TestCase):
                     </iocs>
                     """
 
-        self.assertEqual(len(self.config_utils.get_ioc_macros(xml, "SIMPL").values()), 0)
+        self.assertEqual(len(list(self.config_utils.get_ioc_macros(xml, "SIMPL").values())), 0)
 
     def test_GIVEN_ioc_xml_WHEN_simlevel_is_not_none_THEN_returns_false(self):
         xml = """<?xml version="1.0" ?>

--- a/util/test_utils/test_globals.py
+++ b/util/test_utils/test_globals.py
@@ -161,7 +161,7 @@ class GlobalsTests(unittest.TestCase):
         result = self.utils.get_macros(ioc_name)
 
         # Assert
-        self.assertEqual(len(list(result.keys())), 1)
+        self.assertEqual(len(result.keys()), 1)
         self.assertTrue(macro in result)
         self.assertEqual(result[macro], value)
 
@@ -178,7 +178,7 @@ class GlobalsTests(unittest.TestCase):
         result = self.utils.get_macros("not_" + ioc_name)
 
         # Assert
-        self.assertEqual(len(list(result.keys())), 0)
+        self.assertEqual(len(result.keys()), 0)
 
     def test_GIVEN_a_line_WHEN_value_requested_for_correct_macro_name_THEN_key_and_value_matches_input(self):
         # Arrange
@@ -193,7 +193,7 @@ class GlobalsTests(unittest.TestCase):
         result = self.utils.get_values_of_macro(macro)
 
         # Assert
-        self.assertEqual(len(list(result.keys())), 1)
+        self.assertEqual(len(result.keys()), 1)
         self.assertTrue(macro in result)
         self.assertEqual(result[macro], value)
 
@@ -210,7 +210,7 @@ class GlobalsTests(unittest.TestCase):
         result = self.utils.get_values_of_macro("not_" + ioc_name)
 
         # Assert
-        self.assertEqual(len(list(result.keys())), 0)
+        self.assertEqual(len(result.keys()), 0)
 
     def test_GIVEN_a_line_WHEN_sim_flag_is_set_on_THEN_return_true(self):
         #Arrange

--- a/util/test_utils/test_globals.py
+++ b/util/test_utils/test_globals.py
@@ -161,8 +161,8 @@ class GlobalsTests(unittest.TestCase):
         result = self.utils.get_macros(ioc_name)
 
         # Assert
-        self.assertEqual(len(result.keys()), 1)
-        self.assertTrue(result.has_key(macro))
+        self.assertEqual(len(list(result.keys())), 1)
+        self.assertTrue(macro in result)
         self.assertEqual(result[macro], value)
 
     def test_GIVEN_a_line_WHEN_macro_requested_for_non_existant_ioc_THEN_no_macros_returned(self):
@@ -178,7 +178,7 @@ class GlobalsTests(unittest.TestCase):
         result = self.utils.get_macros("not_" + ioc_name)
 
         # Assert
-        self.assertEqual(len(result.keys()), 0)
+        self.assertEqual(len(list(result.keys())), 0)
 
     def test_GIVEN_a_line_WHEN_value_requested_for_correct_macro_name_THEN_key_and_value_matches_input(self):
         # Arrange
@@ -193,8 +193,8 @@ class GlobalsTests(unittest.TestCase):
         result = self.utils.get_values_of_macro(macro)
 
         # Assert
-        self.assertEqual(len(result.keys()), 1)
-        self.assertTrue(result.has_key(macro))
+        self.assertEqual(len(list(result.keys())), 1)
+        self.assertTrue(macro in result)
         self.assertEqual(result[macro], value)
 
     def test_GIVEN_a_line_WHEN_value_requested_for_incorrect_macro_name_THEN_no_values_returned(self):
@@ -210,7 +210,7 @@ class GlobalsTests(unittest.TestCase):
         result = self.utils.get_values_of_macro("not_" + ioc_name)
 
         # Assert
-        self.assertEqual(len(result.keys()), 0)
+        self.assertEqual(len(list(result.keys())), 0)
 
     def test_GIVEN_a_line_WHEN_sim_flag_is_set_on_THEN_return_true(self):
         #Arrange

--- a/util/test_utils/test_synoptics.py
+++ b/util/test_utils/test_synoptics.py
@@ -80,8 +80,8 @@ class SynopticTests(unittest.TestCase):
             self.synoptic_utils.get_type_target_pairs(xml)
 
         # Assert that the exception contains some kind of useful information
-        self.assertIn("Helium Level Meter", cm.exception.message)
-        self.assertIn("HLG", cm.exception.message)
+        self.assertIn("Helium Level Meter", str(cm.exception))
+        self.assertIn("HLG", str(cm.exception))
 
     def test_GIVEN_a_synoptic_xml_with_no_target_name_WHEN_parsed_THEN_it_is_ignored(self):
         xml = """<?xml version="1.0" ?>

--- a/util/version.py
+++ b/util/version.py
@@ -1,3 +1,5 @@
+from builtins import zip
+from builtins import object
 import os
 
 from util.common import CommonUtils


### PR DESCRIPTION
### Description of work
The .py files in the repo have been passed through [`futurize`](https://python-future.org/futurize.html) and further edited to run on Python 3. The .bat scripts have also been updated to install Genie Python 3 and run the ConfigChecker with it.

### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/4892

### Acceptance criteria
- [x] The unit tests pass when running on Python 3
- [x] Running `run_tests.bat` on this branch gives the same result as running it on `master`

### Documentation
Added a short step to https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Config-Checker to make sure that Python 3 is installed in the right location.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

