### PR TITLE
Print all the IOCs that start with specified name on an instrument

### DIFF
--- a/get_ioc_usage.py
+++ b/get_ioc_usage.py
@@ -56,9 +56,12 @@ def print_instruments_with_ioc(instrument_configs, ioc_name):
     for instrument, iocs in instrument_configs.items():
 
         for ioc in iocs:
-            if ioc.lower().startswith(ioc_name.lower()):
-                print(instrument)
+            ioc_lower = ioc.lower()
+            if ioc_lower == ioc_name.lower():
+                print(f"{instrument}")
                 break
+            elif ioc_lower.startswith(ioc_name.lower()):
+                print(f"{instrument} has {ioc}")
 
 
 def main():

--- a/get_ioc_usage.py
+++ b/get_ioc_usage.py
@@ -52,15 +52,11 @@ def print_instruments_with_ioc(instrument_configs, ioc_name):
     :param instrument_configs: instrument ioc config dictionary
     :param ioc_name: name of the ioc
     """
-    print("All those having the {}".format(ioc_name))
+    print(f"Instruments containing IOCs starting with {ioc_name}")
     for instrument, iocs in instrument_configs.items():
 
         for ioc in iocs:
-            ioc_lower = ioc.lower()
-            if ioc_lower == ioc_name.lower():
-                print(f"{instrument}")
-                break
-            elif ioc_lower.startswith(ioc_name.lower()):
+            if ioc.lower().startswith(ioc_name.lower()):
                 print(f"{instrument} has {ioc}")
 
 


### PR DESCRIPTION
To test:
* Run the config checker with `--ioc G`, confirm you get all the IOCs starting with G listed and they give you the full IOC name